### PR TITLE
Avoid creating new action loops on each key press

### DIFF
--- a/flatris.cabal
+++ b/flatris.cabal
@@ -17,3 +17,9 @@ executable app
                        aeson-pretty,
                        random
   default-language:    Haskell2010
+  other-modules:       Action
+                       Grid
+                       Model
+                       Tetromino
+                       Update
+                       View

--- a/src/Update.hs
+++ b/src/Update.hs
@@ -56,7 +56,7 @@ updateModel MoveRight model@Model {..} =
 updateModel (Time newTime) model = step newModel
   where
     newModel = model {delta = newTime - time model, time = newTime}
-updateModel (GetArrows arr@Arrows {..}) model@Model {..} = step newModel
+updateModel (GetArrows arr@Arrows {..}) model@Model {..} = noEff newModel
   where
     newModel = model {arrows = (arrowX, arrowY)} & checkArrows
 updateModel Init model@Model {..} = model <# (Time <$> now)


### PR DESCRIPTION
Previously each key press was triggering a new loop of `Time` actions
that repeatedly trigger `Time` actions. It doesn’t make sense to have
more than one of these loops and `Init` already starts one.

The miso mario example was also suffering from the same problem, see https://github.com/haskell-miso/miso/pull/280